### PR TITLE
TextFieldコンポーネントの作成

### DIFF
--- a/src/lib/components/TextField/TextField.svelte
+++ b/src/lib/components/TextField/TextField.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import TextFieldOutline from './assets/TextFieldOutline.svelte';
+	import TextFieldStandard from './assets/TextFieldStandard.svelte';
+
+	export let variant: 'outline' | 'standard' | undefined | null = 'standard';
+	export let id: string | null | undefined = Math.random().toString(32).substring(2);
+	export let type: 'text' | 'number' | 'tel' | 'email' | 'url' | 'password' | 'search' | null | undefined = 'text'
+	export let value: string | number | undefined | null = '';
+	export let label: string;
+	// export let onChange: (e: Event & {
+    //     currentTarget: EventTarget & HTMLInputElement;
+    // }) => void
+    $:onChange = (e: Event & {
+        currentTarget: EventTarget & HTMLInputElement;
+    }) => {
+        value = e.currentTarget.value
+    }
+</script>
+
+{#if variant === 'outline'}
+	<TextFieldOutline {id} {type} {label} {onChange} {value}/>
+{:else if variant === 'standard'}
+	<TextFieldStandard {id} {type} {label} {onChange} {value}/>
+{/if}
+

--- a/src/lib/components/TextField/assets/Input.svelte
+++ b/src/lib/components/TextField/assets/Input.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	export let id: string | null | undefined;
+	export let value: string | number | undefined | null = '';
+	export let type: 'text' | 'number' | 'tel' | 'email' | 'url' | 'password' | 'search' | null | undefined = 'text'
+	export let onChange: (e: Event & {
+		currentTarget: EventTarget & HTMLInputElement;
+	}) => void
+</script>
+
+<!-- <input {type} {id} placeholder=" " on:change={onChange} {value} /> -->
+<input {type} {id} placeholder=" " on:input={onChange} {value} />
+
+<style lang="scss">
+	input {
+		border: none;
+		outline: none;
+		height: 1.4em;
+		width: 100%;
+	}
+</style>

--- a/src/lib/components/TextField/assets/TextFieldOutline.svelte
+++ b/src/lib/components/TextField/assets/TextFieldOutline.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	import Input from './Input.svelte';
+
+	export let id: string | null | undefined = Math.random().toString(32).substring(2);
+	export let value: string | number | undefined | null = '';
+	export let type: 'text' | 'number' | 'tel' | 'email' | 'url' | 'password' | 'search' | null | undefined = 'text'
+	export let label: string;
+	export let onChange: (e: Event & {
+		currentTarget: EventTarget & HTMLInputElement;
+	}) => void
+</script>
+
+<div class="text-field-outline">
+	<label for={id}>{label}</label>
+	<Input {id} {type} {onChange} {value} />
+</div>
+
+<style lang="scss">
+	.text-field-outline {
+		margin: 8px;
+		display: flex;
+		align-items: center;
+		height: calc(56px - 2px);
+		width: 25ch;
+		border: 1px solid rgba(0, 0, 0, 0.23);
+		border-radius: 8px;
+		padding: 0 16px;
+		position: relative;
+		user-select: none;
+
+		&:hover {
+			border: 1px solid rgba(0, 0, 0, 0.7);
+		}
+		&:has(input:focus) {
+			border: 2px solid #1976d2;
+			label {
+				color: #1976d2;
+				transform: translate(0, -28px) scale(0.75);
+			}
+		}
+		&:not(:has(input:placeholder-shown)) {
+			border: 2px solid #1976d2;
+			label {
+				color: #1976d2;
+				transform: translate(0, -28px) scale(0.75);
+			}
+		}
+
+		label {
+			position: absolute;
+			padding: 0 4px;
+			color: rgba(0, 0, 0, 0.6);
+			background: #fff;
+			transition: 0.2s;
+			cursor: text;
+		}
+	}
+</style>

--- a/src/lib/components/TextField/assets/TextFieldStandard.svelte
+++ b/src/lib/components/TextField/assets/TextFieldStandard.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+	import Input from './Input.svelte';
+
+	export let id: string | null | undefined = Math.random().toString(32).substring(2);
+	export let value: string | number | undefined | null = '';
+	export let type: 'text' | 'number' | 'tel' | 'email' | 'url' | 'password' | 'search' | null | undefined = 'text'
+	export let label: string;
+    export let onChange: (e: Event & {
+        currentTarget: EventTarget & HTMLInputElement;
+    }) => void
+
+</script>
+
+<div class="text-field-standard">
+	<label for={id}>{label}</label>
+	<div class="text-field-standard__input-container">
+		<Input {id} {type} {onChange} {value} />
+	</div>
+</div>
+
+<style lang="scss">
+	.text-field-standard {
+		margin: 8px;
+		display: flex;
+		align-items: center;
+		height: calc(56px - 8px * 2);
+		width: 25ch;
+		position: relative;
+		user-select: none;
+		padding: 8px 0;
+		&:hover {
+			.text-field-standard__input-container::before {
+				border-bottom: 2px solid rgba(0, 0, 0, 0.7);
+			}
+		}
+
+		label {
+			position: absolute;
+			color: rgba(0, 0, 0, 0.6);
+			// background: #fff;
+			transition: 0.2s;
+			cursor: text;
+			z-index: 1;
+			left: 16px;
+			user-select: none;
+
+			&:has(+ .text-field-standard__input-container > input:focus) {
+				color: #1976d2;
+				transform: translate(0, -16px) scale(0.75);
+			}
+			&:not(:has(+ .text-field-standard__input-container > input:placeholder-shown)) {
+				color: #1976d2;
+				transform: translate(0, -16px) scale(0.75);
+			}
+		}
+		.text-field-standard__input-container {
+			display: inline-flex;
+			align-items: flex-end;
+			width: 100%;
+			height: calc(100% - 8px * 2);
+			padding: 8px 0;
+			position: relative;
+
+			&::before {
+				position: absolute;
+				border-bottom: 1px solid rgba(0, 0, 0, 0.42);
+				content: '';
+				bottom: 0;
+				left: 0;
+				right: 0;
+				transition: 0.1s;
+			}
+			&::after {
+				position: absolute;
+				border-bottom: 2px solid #1976d2;
+				content: '';
+				bottom: 0;
+				left: 0;
+				right: 0;
+				transition: 0.2s;
+				transform: scaleX(0);
+			}
+
+			&:has(input:focus) {
+				&::after {
+					transform: scaleX(1);
+				}
+			}
+			&:not(:has(input:placeholder-shown)) {
+				&::after {
+					transform: scaleX(1);
+				}
+			}
+		}
+	}
+</style>

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,0 +1,14 @@
+export type AuthForm = {
+    email: string
+    password: string
+}
+export type EditedProject = {
+    id: number
+    projectName: string;
+    when?: string | null;
+    where?: string | null;
+    who?: string | null;
+    what?: string | null;
+    why?: string | null;
+    how?: string | null;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,6 +4,16 @@
 <slot />
 
 <style>
+	:global(input) {
+		padding: 0;
+		margin: 0;
+		border: none;
+		outline: none;
+	}
+	:global(fieldset) {
+		margin: 0;
+		text-align: left;
+	}
 	:global(a) {
 		color: inherit;
 		text-decoration: none;
@@ -17,5 +27,12 @@
 		src: url(static/fonts/LINESeedJP_OTF_Eb.woff);
 		src: url(static/fonts/LINESeedJP_OTF_Rg.woff);
 		src: url(static/fonts/LINESeedJP_OTF_Th.woff);
+		color: #1a2027;
+		font-size: 1rem;
+		margin: 0;
+		text-align: center;
+	}
+	* {
+		box-sizing: border-box;
 	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,9 +1,29 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to read the documentation</p>
-<div class="parent">
-    <div class="child"></div>
-</div>
+<script lang="ts">
+	import TextField from "$lib/components/TextField/TextField.svelte";
+
+	let isRegister = false;
+	export let value: string | number | undefined | null = '';
+
+</script>
+
+<main>
+	<img
+        class="register-icon"
+		src="/imgs/{isRegister ? 'account-create.svg' : 'login.svg'}"
+		alt={isRegister ? 'create account' : 'login'}
+	/>
+    <TextField label="test" variant='outline' type="text" {value}/>
+</main>
 
 <style lang="scss">
+    main{
+        display: flex;
+        flex-direction: column;
+        align-items: center;
 
+        .register-icon {
+            width: 80px;
+            height: 80px;
+        }
+    }
 </style>


### PR DESCRIPTION
- variantpropsで`outline`、`standard`の選択可
- 内部でchangeハンドラを生成するため自作しなくてよい。代わりにvalueのみpropsとして渡す。
- changeハンドラは`on:change`ではなく、`on:input`に渡している。